### PR TITLE
Pass in custom request parameters to speechToText

### DIFF
--- a/lib/watson.js
+++ b/lib/watson.js
@@ -6,7 +6,8 @@
 
 // !Dependencies
 var fs = require('fs'),
-	request = require('request');
+	request = require('request'),
+	merge = require('merge-descriptors');
 
 // !Set up the client options and defaults
 var Watson = exports.Watson = function(options) {
@@ -50,25 +51,47 @@ Watson.prototype.getAccessToken = function(callback) {
     	if(error) {
 			error = new Error('Failed to get access token.');
     	}
+
+    	this.access_token = JSON.parse(body)['access_token'];
+
     	// Pass any errors and the Access Token back to the app
-    	callback(error, JSON.parse(body)['access_token']);
+    	callback(error, this.access_token );
 	});
 };
 
 // !SpeechToText API Call Wrapper
-Watson.prototype.speechToText = function(speechFile, accessToken, callback) {
+Watson.prototype.speechToText = function(speechFile, reqParams, callback) {
+
+	var reqHeaders = {
+		'Accept': 'application/json',
+		'Authorization': 'Bearer ' + this.access_token,
+		'Content-Type': 'audio/wav',
+		'X-SpeechContext': this.context,			// Possible Values: Generic, UVerseEPG, BusinessSearch, Websearch, SMS, Voicemail, QuestionAndAnswer
+		'X-Arg': this.xarg							// Occasionally used for custom grammar sets. Unnecessary by default.
+	};
+
+	// get a call back
+	callback = arguments[ arguments.length - 1 ];
+
+	// make sure we have an access_token
+	if( this.access_token === null )
+		throw new Error( 'Call the getAccessToken function or pass in "access_token" in the constructor options before calling speechToText' );
+
+	// ensure that we have a callback. This function is sort of pointless without a callback
+	if( typeof callback != 'function' )
+		throw new Error( 'The last argument you pass in must be a callback function' );
+
+	// add the params to the request headers
+	// possible parameter values can be seen here under request parameters: http://developer.att.com/apis/speech/docs/v3
+	merge( reqHeaders, reqParams );
+
 	// !Details of the API Call Request
 	var request_details = {
 		method: 'POST',
-		headers: {
-			'Accept': 'application/json',
-			'Authorization': 'Bearer ' + accessToken,	// Access Token must be retrieved before making API Calls
-			'Content-Type': 'audio/wav',				// TODO: Add dynamic support for audio/amr
-			'X-SpeechContext': this.context,			// Possible Values: Generic, UVerseEPG, BusinessSearch, Websearch, SMS, Voicemail, QuestionAndAnswer
-			'X-Arg': this.xarg							// Occasionally used for custom grammar sets. Unnecessary by default.
-		},
+		headers: reqHeaders,
 		uri: "https://" + this.api_domain + "/speech/v3/speechToText"
 	};
+
 	// !Pipe the Speech file from the Node.js server to the AT&T API server
 	fs.createReadStream(speechFile).pipe(request(
 				request_details,

--- a/package.json
+++ b/package.json
@@ -10,8 +10,19 @@
   "main": "./lib/watson",
   "dependencies": {
     "oauth": ">= 0.9.8",
-    "request": ">= 1.9.0"
+    "request": ">= 1.9.0",
+    "merge-descriptors": "0.0.2"
   },
-  "engines": { "node": ">= 0.4.0" },
-  "keywords": ["att", "audio", "speechtotext", "speech2text", "speech", "api", "wrapper"]
+  "engines": {
+    "node": ">= 0.4.0"
+  },
+  "keywords": [
+    "att",
+    "audio",
+    "speechtotext",
+    "speech2text",
+    "speech",
+    "api",
+    "wrapper"
+  ]
 }


### PR DESCRIPTION
Made it so that you can pass a an object which represents request parameters to the speech api. (allowing you to change language or audio file type for instance).

Also changed it so that access token is saved when `getAccessToken` is called. This makes it redundant to have to pass in an accessToken to speechToText function since you'll have either passed it through the constructor or called `getAccessToken`.
