### PR TITLE
Fixes getAccessToken to actually set access_token

### DIFF
--- a/lib/watson.js
+++ b/lib/watson.js
@@ -30,32 +30,35 @@ Watson.prototype.getAccessToken = function(callback) {
 		grant_type: "client_credentials",
 		scope: this.scope
     };
-    
+
     // Create the Param String
     var paramlist  = [];
     for (pk in request_params) {
 		paramlist.push(pk + "=" + request_params[pk]);
     };
     var body_string = paramlist.join("&");
-    
+
     // !Details of the OAuth 2.0 Request
-    var request_details = {  
+    var request_details = {
 		method: "POST",
 		headers: {'content-type' : 'application/x-www-form-urlencoded'},
 		uri: this.access_token_url,
 		body: body_string
     };
-    
+
+    var self = this;
+
     // !Make the request
     request(request_details, function(error, response, body) {
+
     	if(error) {
 			error = new Error('Failed to get access token.');
     	}
 
-    	this.access_token = JSON.parse(body)['access_token'];
+        self.access_token = JSON.parse(body)['access_token'];
 
     	// Pass any errors and the Access Token back to the app
-    	callback(error, this.access_token );
+        callback(error, self.access_token );
 	});
 };
 


### PR DESCRIPTION
This fixes getAccessToken so that it appends itself onto the Watson
class and not the callback function from request.
